### PR TITLE
fix: fix price chart decimal points

### DIFF
--- a/src/components/ui/Pool/PoolPriceChart.tsx
+++ b/src/components/ui/Pool/PoolPriceChart.tsx
@@ -63,16 +63,16 @@ export const PoolPriceChart = ({ address, timeFrame }: PoolPriceChartProps) => {
         />
         <YAxis
           axisLine={false}
-          width={40}
+          width={70}
           tickLine={false}
           className="text-xs"
-          tickFormatter={formatDollarValueNumber}
+          tickFormatter={(v) => formatDollarValueNumber(v, 7)}
         />
         <Tooltip
           cursor={{ radius: 3, fillOpacity: 0.1 }}
           contentStyle={{ backgroundColor: "rgba(0,0,0,0.7)", border: "none", fontSize: "14px" }}
-          formatter={(value, name, props) => {
-            return [formatDollarValueNumber(value as number), "Price"]
+          formatter={(value) => {
+            return [formatDollarValueNumber(value as number, 7), "Price"]
           }}
           labelFormatter={(v) => dayjs(v).format("DD.MMM YYYY HH:mm")}
         />


### PR DESCRIPTION
Fix price chart decimal points. Issue: #128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `PoolPriceChart` with improved Y-axis and tooltip formatting for better clarity.
	- Dollar values are now displayed with increased precision (7 decimal places) for more accurate financial representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->