### PR TITLE
first try to fix manual input font

### DIFF
--- a/src/components/ui/Swap/SwapSettingModal.module.scss
+++ b/src/components/ui/Swap/SwapSettingModal.module.scss
@@ -6,3 +6,33 @@
   background-color: #0439c7;
   border-radius: var(--mantine-radius-sm);
 }
+
+.inputField {
+  /* Use CSS variables for font size and line height */
+  font-size: var(--text-fz, var(--mantine-font-size-xs));
+  line-height: var(--text-lh, var(--mantine-line-height-xs));
+
+  /* Ensure consistent font weight and transformation */
+  font-weight: 600;
+  text-transform: uppercase;
+
+  /* Text alignment */
+  text-align: center;
+  @media (min-width: 768px) { /* md breakpoint */
+    text-align: start;
+  }
+
+  /* Background and text color */
+  background-color: var(--turq);
+  color: black;
+
+  /* Remove borders and rounding */
+  border: transparent;
+  border-radius: 0;
+
+  /* Override global letter-spacing */
+  letter-spacing: 0;
+
+  /* min-height to match the buttons height */
+   min-height: 41.5px;
+}

--- a/src/components/ui/Swap/SwapSettingModal.tsx
+++ b/src/components/ui/Swap/SwapSettingModal.tsx
@@ -72,10 +72,7 @@ export const SwapSettingModal = (props: SwapSettingProps) => {
           <NumberInput
             classNames={{
               root: "w-auto",
-              input: clsx(
-                dogica.className,
-                "text-center  md:text-start bg_turq text-black text-xs h-[42px] border-transparent rounded-none"
-              ),
+              input: clsx(dogica.className, classes.inputField),
             }}
             defaultValue={swapSlippage}
             value={swapSlippage}
@@ -153,7 +150,7 @@ export const SwapSettingModal = (props: SwapSettingProps) => {
               root: "w-auto",
               input: clsx(
                 dogica.className,
-                "text-center  md:text-start bg_turq text-black text-xs  h-[42px] border-transparent rounded-none"
+                classes.inputField
               ),
             }}
             defaultValue={zapSlippage}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new CSS class `.inputField` for improved styling in the Swap Setting Modal.
  
- **Bug Fixes**
	- Updated the styling of `NumberInput` components for slippage settings to ensure consistent appearance across the modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->