### PR TITLE
Fixed swap delay loading and lagging issue

### DIFF
--- a/src/components/ui/Swap/SwapHome.tsx
+++ b/src/components/ui/Swap/SwapHome.tsx
@@ -79,11 +79,11 @@ export const SwapHome = ({ onSetting }: SwapHomeProps) => {
     );
   };
 
-  const debouncedInputValue = useDebounce(inputValue, 500);
+  const {debouncedInputValue, isInputChanging} = useDebounce(inputValue, 500);
 
   const {
     isLoading:fetchLoading, 
-    isError:fetchError,
+    isError:fetchError
   } = useQuery({
     queryKey: [inputTokenIndex, outputTokenIndex, debouncedInputValue],
     refetchInterval: 10000,
@@ -152,6 +152,7 @@ export const SwapHome = ({ onSetting }: SwapHomeProps) => {
       setOutputTokenIndex(tempIndex);
     }
   };
+
 
   return (
     <>
@@ -257,7 +258,8 @@ export const SwapHome = ({ onSetting }: SwapHomeProps) => {
               text-start bg-transparent text-white text-2xl h-auto overflow-x-auto
               border-transparent rounded-none`}
             >
-              {routeData
+              {isInputChanging || fetchLoading ? <Typography secondary className="animate-pulse">Loading...</Typography> :
+              routeData
                 ? Number(
                   formatStringUnits(
                     routeData.routeSummary.amountOut,

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -13,7 +13,7 @@ export const useDebounce = (value: number, delay: number) => {
 
       const delayChange = setTimeout(() => {
         setIsInputChanging(false) 
-      },2400)
+      },2700)
  
       return () => {
         clearTimeout(delayChange);

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,15 +1,24 @@
+"use-client"
 import { useEffect, useState } from "react";
 
 export const useDebounce = (value: number, delay: number) => {
-    const [debouncedValue, setDebouncedValue] = useState(value);
+    const [debouncedInputValue, setDebouncedInputValue] = useState(value);
+    const [isInputChanging, setIsInputChanging] = useState(false)
+
     useEffect(() => {
+      setIsInputChanging(true)
       const handler = setTimeout(() => {
-        setDebouncedValue(value);
+        setDebouncedInputValue(value);
       }, delay);
-  
+
+      const delayChange = setTimeout(() => {
+        setIsInputChanging(false) 
+      },2400)
+ 
       return () => {
+        clearTimeout(delayChange);
         clearTimeout(handler);
       };
     }, [value, delay]);
-    return debouncedValue;
+    return {debouncedInputValue, isInputChanging};
   };


### PR DESCRIPTION
Since the values kept changing on input change, I've used the isLoading from tanstack, also added a dynamic loading in useDebounce hook. When the user changes the input or data is fetching, it will display "loading".
Still, there was some lagging values of previous inputs shown even when datas were changed, I feel the lagging was due to calculation time because multiple functions were sandwiched...so I've added extra 2.5 sec to calculate and display only final data (nothing in between datas).