### PR TITLE
chore: disable merge based on contract status

### DIFF
--- a/src/components/ui/Merge/Memes/MemeMergeForm.tsx
+++ b/src/components/ui/Merge/Memes/MemeMergeForm.tsx
@@ -13,7 +13,7 @@ import { useConnectModal } from '@rainbow-me/rainbowkit'
 import * as dn from "dnum"
 import MergeProcessingModal from './MergeProcessingModal'
 import { ethers, formatUnits } from 'ethers'
-import { useMemeEaterRate, useMemeGetTotalWeWe, useVestingsInfo } from '~/hooks/useMemeEater'
+import { useMemeEaterIsPaused, useMemeEaterRate, useMemeGetTotalWeWe, useVestingsInfo } from '~/hooks/useMemeEater'
 import { MergeConfig } from '~/constants/mergeConfigs'
 
 interface MemeMergeFormProps {
@@ -30,6 +30,7 @@ const MemeMergeForm = ({ mergeConfig }: MemeMergeFormProps) => {
   const [isComplete, setIsComplete] = useState(false)
   const [hash, setHash] = useState<Hex>()
   const { rate, isLoading: isRateLoading } = useMemeEaterRate(mergeConfig.eaterContractAddress);
+  const { isPaused } = useMemeEaterIsPaused(mergeConfig.eaterContractAddress);
 
   const amountBigNumber = ethers.parseUnits(amount || "0", mergeConfig.inputToken.decimals);
 
@@ -158,7 +159,7 @@ const MemeMergeForm = ({ mergeConfig }: MemeMergeFormProps) => {
           <div className="flex-1 flex flex-col sm:flex-row items-center gap-3 ">
             <Button
               className="flex items-center justify-center gap-3 w-full md:w-auto md:h-[62px]"
-              disabled={mergeConfig.isMergeDisabled || !address || !amount}
+              disabled={mergeConfig.isMergeDisabled || !address || !amount || isPaused}
               onClick={
                 isConnected
                   ? () => handleMerge()

--- a/src/constants/mergeConfigs.ts
+++ b/src/constants/mergeConfigs.ts
@@ -25,7 +25,7 @@ const fomoMergeConfig: MergeConfig = {
   uniAdaptorAddress: "0xbb1a07e99f7638dcC730b523e1b107FdC7c379Ac" as `0x${string}`,
   chartUrl: "https://dexscreener.com/base/0x7bCD8185B7f4171017397993345726E15457B1eE?embed=1&theme=dark&trades=0&info=0",
   mergeDeadline: dayjs().year(2024).month(9).date(31).format("DD.MMM"),
-  isMergeDisabled: true,
+  isMergeDisabled: false,
 }
 
 

--- a/src/hooks/useMemeEater.ts
+++ b/src/hooks/useMemeEater.ts
@@ -171,3 +171,26 @@ export function useMemeGetTotalWeWe(eaterAddress: Hex, amount: bigint) {
     isLoading
   }
 }
+
+
+export function useMemeEaterIsPaused(eaterAddress: Hex) {
+  const { data, isLoading, refetch } = useReadContract({
+    abi: MemeEaterAbi,
+    address: eaterAddress,
+    functionName: "paused",
+  });
+
+  useWatchContractEvent({
+    address: eaterAddress,
+    abi: MemeEaterAbi,
+    eventName: "Paused",
+    onLogs: () => {
+      refetch();
+    },
+  });
+
+  return {
+    isPaused: data,
+    isLoading
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new hook to check if the Meme Eater contract is paused.
	- Updated the merge button to be disabled when the contract is paused, enhancing user experience and preventing unintended actions.

- **Bug Fixes**
	- Changed the merge configuration to enable merging by setting `isMergeDisabled` to false.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->