### PR TITLE
made merger page default while opening the app

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,7 @@ export default function Home() {
   const router = useRouter();
 
   useEffect(() => {
-    router.push("/pools");
+    router.push("/merge");
   }, []);
 
   return <></>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The initial navigation of the Home component has been updated to redirect users to the `/merge` page upon loading, enhancing user experience by streamlining access to relevant content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->